### PR TITLE
Parse CLI args before bundle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ enum Commands {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+
     let input = std::io::stdin();
 
     let bundle: Bundle = if input.is_terminal() {
@@ -42,8 +44,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Read from stdin
         serde_yaml::from_reader(input.lock())?
     };
-
-    let cli = Cli::parse();
 
     let graph = bundle.to_graph();
 


### PR DESCRIPTION
Running `juju-graph --help` without piping in a bundle currently complains that no file can be found (i.e. if there is no `bundle.yml` in `.`). This PR moves CLI arg parsing earlier so that it is the first thing done by `juju-graph`
