### PR TITLE
Make `spotlight` argument an `Option`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,15 +48,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let graph = bundle.to_graph();
 
     match &cli.command {
-<<<<<<< chore/cli-spotlight-option
-        Some(Commands::Mermaid { url, spotlight }) => {
-            let graph = if let Some(spotlight) = spotlight {
-=======
         Commands::Mermaid { url, spotlight } => {
-            let graph = if spotlight.is_empty() {
-                graph
-            } else {
->>>>>>> main
+            let graph = if let Some(spotlight) = spotlight {
                 graph.neighbors(spotlight)
             } else {
                 graph
@@ -69,15 +62,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 println!("{}", graph.graph.to_mermaid());
             }
         }
-<<<<<<< chore/cli-spotlight-option
-        Some(Commands::Graphviz { spotlight }) => {
-            let graph = if let Some(spotlight) = spotlight {
-=======
         Commands::Graphviz { spotlight } => {
-            let graph = if spotlight.is_empty() {
-                graph
-            } else {
->>>>>>> main
+            let graph = if let Some(spotlight) = spotlight {
                 graph.neighbors(spotlight)
             } else {
                 graph

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,12 @@ enum Commands {
     Mermaid {
         #[arg(long)]
         url: bool,
-        #[arg(long, default_value = "")]
-        spotlight: String,
+        #[arg(long)]
+        spotlight: Option<String>,
     },
     Graphviz {
-        #[arg(long, default_value = "")]
-        spotlight: String,
+        #[arg(long)]
+        spotlight: Option<String>,
     },
 }
 
@@ -49,10 +49,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match &cli.command {
         Some(Commands::Mermaid { url, spotlight }) => {
-            let graph = if spotlight.is_empty() {
-                graph
-            } else {
+            let graph = if let Some(spotlight) = spotlight {
                 graph.neighbors(spotlight)
+            } else {
+                graph
             };
 
             if *url {
@@ -63,10 +63,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         Some(Commands::Graphviz { spotlight }) => {
-            let graph = if spotlight.is_empty() {
-                graph
-            } else {
+            let graph = if let Some(spotlight) = spotlight {
                 graph.neighbors(spotlight)
+            } else {
+                graph
             };
             println!("{}", graph.graph.to_graphviz());
         }


### PR DESCRIPTION
Currently the `spotlight` argument is a `String` which must be checked against `""` to see whether it has been passed. It would be nice to enforce this check through the type system, hence this PR proposes changing the type of this field to `Option<String>`. The only functional difference here is that a user could pass `juju-graph ... --spotlight=""` getting the neighbours, but at that point I think the user is going to some lengths to do something silly so I think it's okay to ignore this case.

This PR may conflict with #1, although it's nothing serious
